### PR TITLE
Update recipes to build with yocto/openembedded dunfell (3.1)

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,19 +1,32 @@
 MODULE_NAME = imx_pwm_audio
 OUT = $(MODULE_NAME).ko
 
+# Tools directory is available in https://github.com/Glowforge/kernel-module-glowforge/
+TOOLS_DIR = ../tools
+SDMA_ASSEMBLER = PERL5LIB=$(TOOLS_DIR) $(TOOLS_DIR)/sdma_asm.pl
+
 KERNEL_SRC ?= /usr/src/kernel
+
+ASM = imx_pwm_audio_sdma.asm
 
 ccflags-y += -Wno-unknown-pragmas
 
 obj-m += $(MODULE_NAME).o
 
+SDMA_SCRIPT = $(ASM)
+SDMA_SCRIPT_ASSEMBLED = $(ASM:.asm=.asm.h)
+
 .PHONY: all clean modules_install
 
-all:
+all: $(SDMA_SCRIPT_ASSEMBLED)
 	$(MAKE) -C $(KERNEL_SRC) M=$(PWD) modules
+
+%.asm.h: %.asm
+	$(SDMA_ASSEMBLER) $< > $@
 
 modules_install:
 	$(MAKE) -C $(KERNEL_SRC) M=$(PWD) modules_install
 
 clean:
 	$(MAKE) -C $(KERNEL_SRC) M=$(PWD) clean
+	rm -f $(SDMA_SCRIPT_ASSEMBLED)

--- a/README
+++ b/README
@@ -1,5 +1,5 @@
 i.MX PWM audio driver
-Copyright (C) 2016-2018 Glowforge, Inc. <opensource@glowforge.com>
+Copyright (C) 2016-2021 Glowforge, Inc. <opensource@glowforge.com>
 
 This program is free software; you can redistribute it and/or modify
 it under the terms of the GNU General Public License as published by

--- a/imx_pwm_audio_sdma.asm
+++ b/imx_pwm_audio_sdma.asm
@@ -1,35 +1,67 @@
+# arguments:
+#   r5  - sample size bitmask; (1<<bits)-1
+#   r6  - offset; value subtracted from each sample (e.g. to convert signed to unsigned)
+#   r7  - physical address of buffer end
+#   MDA - PWMSAR register
+#   MSA - physical address of buffer start
+#   MS  - 0x00100000 (destination address frozen; source address postincrement; start in read mode)
+#   PDA - EPIT_SR address
+#   PS  - 0x000c0400 (destination address frozen; 32-bit write size; start in write mode)
+#
+# register usage:
+#   r1  - constant, always 1
+#   r2  - temporary
+
 start:
   ldi r2, 0
-  ldi r1, 1
-  stf r1, 0xc8
+  ldi r1, 1     # constant
+  # Do nothing the first time around.
+  # Clear the timer interrupt and wait for another timer tick.
+  # This ensures we perform exactly one iteration when the script starts.
+  # (The very first time the script is loaded, execution starts when the channel
+  # priority is set. If there is also a pending timer event, we could wind up
+  # doing two ticks worth of work in one.)
+  stf r1, 0xc8  # (PD)
   done 4
 
 update:
-  stf r1, 0xc8
-  stf r2, 0x2b
-  ldf r2, 0x00
+  # clear EPIT interrupt flag
+  stf r1, 0xc8  # (PD)
+
+  # reload the previous sample to prevent a glitch
+  stf r2, 0x2b # (MD|SZ32|FL)
+
+  # stop if we've advanced past the end of the sample data
+  ldf r2, 0x00  # (MSA)
   cmphs r2, r7
   bt alldone
+
+  # get new sample (1 or 2 bytes)
   btsti r5, 8
   bt read16bit
-  ldf r2, 0x09
+  ldf r2, 0x09 # (MD|SZ8) read one byte; increment source address by 1
 
 output:
+  # subtract offset
   sub r2, r6
+  # mask out unused bits
   and r2, r5
-  stf r2, 0x2b
+  # output new sample
+  stf r2, 0x2b # (MD|SZ32|FL)
 
+  # wait for next timer interrupt
   done 4
-  btsti r1, 0
+  btsti r1, 0   # always true
   bt update
 
 alldone:
-  done 3
+  done 3  # trigger a host interrupt
   done 4
-  btsti r1, 0
+  # when script is restarted, jump back to the beginning
+  btsti r1, 0   # always true
   bt update
 
 
 read16bit:
-  ldf r2, 0x0a
-  bt output
+  ldf r2, 0x0a # (MD|SZ16) read two bytes; increment source address by 2
+  bt output # T is still set


### PR DESCRIPTION
This brings this kernel module up to date with the 5.4.3 (imx) linux kernel.

This was built with the 2.0.0 Glowforge release, build 2039.
This build was released the week of 2021-02-22.